### PR TITLE
use fixed point math for analogsensor

### DIFF
--- a/inc/drivers/AnalogSensor.h
+++ b/inc/drivers/AnalogSensor.h
@@ -58,7 +58,7 @@ class AnalogSensor : public DeviceComponent
 
     DevicePin       &_pin;              // Pin where the sensor is connected.
     uint16_t        samplePeriod;       // The time between samples, in milliseconds.
-    float           sensitivity;        // A value between 0..1 used with a decay average to smooth the sample data. 
+    uint16_t        sensitivity;        // A value between 0..1023 used with a decay average to smooth the sample data. 
     uint16_t        highThreshold;      // threshold at which a HIGH event is generated
     uint16_t        lowThreshold;       // threshold at which a LOW event is generated
     int             sensorValue;        // Last sampled data.
@@ -145,11 +145,11 @@ class AnalogSensor : public DeviceComponent
     /**
       * Set smoothing value for the data. A decay average is taken of sampled data to smooth it into more accurate information.
       *
-      * @param value A value between 0..1 that detemrines the level of smoothing. Set to 0 to disable smoothing. Default value is 0.1
+      * @param value A value between 0..1023 that detemrines the level of smoothing. Set to 1023 to disable smoothing. Default value is 868
       *
       * @return DEVICE_OK on success, DEVICE_INVALID_PARAMETER if the request fails.
       */
-    int setSensitivity(float value);
+    int setSensitivity(uint16_t value);
 
     /**
       * Destructor.

--- a/source/drivers/AnalogSensor.cpp
+++ b/source/drivers/AnalogSensor.cpp
@@ -48,7 +48,7 @@ DEALINGS IN THE SOFTWARE.
 AnalogSensor::AnalogSensor(DevicePin &pin, uint16_t id) : _pin(pin)
 {
     this->id = id;
-    this->sensitivity = 0.1f;
+    this->sensitivity = 868;
 
     // Configure for a 2 Hz update frequency by default. 
     if(EventModel::defaultEventBus)
@@ -81,9 +81,7 @@ int AnalogSensor::getValue()
  */
 void AnalogSensor::updateSample()
 {
-    float value;
-
-    value = _pin.getAnalogValue();
+    int value = _pin.getAnalogValue();
 
     // If this is the first reading performed, take it a a baseline. Otherwise, perform a decay average to smooth out the data.
     if (!(status & ANALOG_SENSOR_INITIALISED))
@@ -93,7 +91,7 @@ void AnalogSensor::updateSample()
     }
     else
     {
-        sensorValue = (sensorValue * (1.0f - sensitivity)) + (value * sensitivity);
+        sensorValue = ((sensorValue * (1023 - sensitivity)) + (value * sensitivity)) >> 10;
     }
 
     checkThresholding();
@@ -123,13 +121,13 @@ void AnalogSensor::checkThresholding()
 /**
  * Set sensitivity value for the data. A decay average is taken of sampled data to smooth it into more accurate information.
  *
- * @param value A value between 0..1 that detemrines the level of smoothing. Set to 0 to disable smoothing. Default value is 0.1
+ * @param value A value between 0..1023 that detemrines the level of smoothing. Set to 1023 to disable smoothing. Default value is 868
  *
  * @return DEVICE_OK on success, DEVICE_INVALID_PARAMETER if the request fails.
  */
-int AnalogSensor::setSensitivity(float value)
+int AnalogSensor::setSensitivity(uint16_t value)
 {
-    this->sensitivity = value;
+    this->sensitivity = max(0, min(1023, value));
 
     return DEVICE_OK;
 }


### PR DESCRIPTION
Don't use float to compute first-order filter of sensor data