### PR TITLE
Allow `./build.py https://github.com/foobar/codal-my-board#tag` with a a specified commit, branch or release tag

### DIFF
--- a/build.py
+++ b/build.py
@@ -93,10 +93,16 @@ if len(args) == 1:
         break
 
     if target_config == None and target_name.startswith("http"):
+        name = re.sub(r"(^.*)/([^#]*)#(.*)", r"\2", target_name)
+        url = target_name
+        branch = "master"
+        if '#' in target_name:
+            branch = re.sub(r"(^.*)/([^#]*)#(.*)", r"\3", target_name)
+            url = re.sub(r"(^.*)/([^#]*)#(.*)", r"\1/\2", target_name)
         target_config = {
-            "name": re.sub("^.*/", "", target_name),
-            "url": target_name,
-            "branch": "master",
+            "name": name,
+            "url": url,
+            "branch": branch,
             "type": "git"
         }
 


### PR DESCRIPTION
Hello,
In order to simplify the test of a specific target, I needed to compile a codal target in a specific state. In the same mind as https://github.com/lancaster-university/codal-docker/pull/1. 

Like in a npm dependency, if #<commit-ish> is provided, it will be used to clone exactly that commit/tag/branch.