### PR TITLE
Account for main being used instead of master in lock code

### DIFF
--- a/utils/python/codal_utils.py
+++ b/utils/python/codal_utils.py
@@ -93,8 +93,8 @@ def get_next_version(options):
     v2 = int(m.group(3))
     vB = -1
     branchName = os.popen('git rev-parse --abbrev-ref HEAD').read().strip()
-    if not options.branch and branchName != "master":
-        print("On non-master branch use -l -b")
+    if not options.branch and branchName not in ["master","main"]:
+        print("On feature branch use -l -b")
         exit(1)
     suff = ""
     if options.branch:


### PR DESCRIPTION
Main is now being used for some codal targets as the critical branch. Update code so that main is considered a critical branch when version locking