### PR TITLE
Feature/bootstrap - Create new C/C++ projects with reference to the upstream tooling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,10 @@
 cmake_minimum_required(VERSION 3.3)
 
 # include additional cmake
-include(utils/cmake/JSONParser.cmake)
-include(utils/cmake/util.cmake)
-include(utils/cmake/colours.cmake)
+set( CORE_PATH "libraries/codal" )
+include(${CORE_PATH}/utils/cmake/JSONParser.cmake)
+include(${CORE_PATH}/utils/cmake/util.cmake)
+include(${CORE_PATH}/utils/cmake/colours.cmake)
 
 if (NOT "${BUILD_TOOL}" STRGREATER "")
     set(BUILD_TOOL "CODAL")
@@ -95,7 +96,7 @@ endif()
 ####################
 
 SET(TOOLCHAIN ${device.toolchain})
-SET(TOOLCHAIN_FOLDER "${CMAKE_CURRENT_LIST_DIR}/utils/cmake/toolchains/${device.toolchain}")
+SET(TOOLCHAIN_FOLDER "${CMAKE_CURRENT_LIST_DIR}/${CORE_PATH}/utils/cmake/toolchains/${device.toolchain}")
 
 # include toolchain file
 set(CMAKE_TOOLCHAIN_FILE "${TOOLCHAIN_FOLDER}/toolchain.cmake" CACHE PATH "toolchain file")
@@ -106,7 +107,7 @@ enable_language(ASM)
 
 # include compiler flags overrides
 include(${TOOLCHAIN_FOLDER}/compiler-flags.cmake)
-set(PLATFORM_INCLUDES_PATH "${PROJECT_SOURCE_DIR}/utils/cmake/toolchains/${device.toolchain}")
+set(PLATFORM_INCLUDES_PATH "${PROJECT_SOURCE_DIR}/${CORE_PATH}/utils/cmake/toolchains/${device.toolchain}")
 
 file(MAKE_DIRECTORY "${PROJECT_SOURCE_DIR}/build")
 
@@ -193,7 +194,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${PLATFORM_INCLUDES_PATH}")
 set(CODAL_BUILD_SYSTEM TRUE)
 
 # a define specificying common utils used in codal
-set(CODAL_UTILS_LOCATION "${PROJECT_SOURCE_DIR}/utils/cmake/util.cmake")
+set(CODAL_UTILS_LOCATION "${PROJECT_SOURCE_DIR}/${CORE_PATH}/utils/cmake/util.cmake")
 
 # this variable is used in the linking step of the final binary.
 set(LIB_FOLDERS "")
@@ -268,12 +269,12 @@ endif()
 if ("${BUILD_TOOL}" STRGREATER "")
     string(COMPARE EQUAL "${BUILD_TOOL}" "YOTTA" YOTTA_BUILD)
     if (${YOTTA_BUILD})
-        include("${PROJECT_SOURCE_DIR}/utils/cmake/buildtools/yotta.cmake")
+        include("${PROJECT_SOURCE_DIR}/${CORE_PATH}/utils/cmake/buildtools/yotta.cmake")
     endif ()
 
     string(COMPARE EQUAL "${BUILD_TOOL}" "CODAL" CODAL_BUILD)
     if (${CODAL_BUILD})
-        include("${PROJECT_SOURCE_DIR}/utils/cmake/buildtools/codal.cmake")
+        include("${PROJECT_SOURCE_DIR}/${CORE_PATH}/utils/cmake/buildtools/codal.cmake")
     endif()
 endif()
 

--- a/build.py
+++ b/build.py
@@ -61,10 +61,12 @@ if options.status:
     status()
     exit(0)
 
+os.environ
+
 # out of source build!
 os.chdir("build")
 
-test_json = read_json("../utils/targets.json")
+test_json = read_json("../libraries/codal/utils/targets.json")
 
 # configure the target a user has specified:
 if len(args) == 1:

--- a/utils/python/codal_utils.py
+++ b/utils/python/codal_utils.py
@@ -67,7 +67,7 @@ def update():
 
 def printstatus():
     print("\n***%s" % os.getcwd())
-    system("git status -s")
+    system("git status -sb")
 
 def status():
     (codal, targetdir, target) = read_config()


### PR DESCRIPTION
Tracking the `feature/bootstrap` branch here, where changes have been made to allow codal to run as a library in a larger project, rather than requiring the build system to be copied over to each new project.

See also https://github.com/lancaster-university/codal-bootstrap for the bootstrap code, where the local build.py acts as a proxy for the codal one.

(More details to follow)