### PR TITLE
Add --verbose flag to build.py

### DIFF
--- a/build.py
+++ b/build.py
@@ -39,6 +39,7 @@ parser.add_option('-b', '--branch', dest='branch', action="store_true", help='Wi
 parser.add_option('-m', '--minor', dest='update_minor', action="store_true", help='With -l, update minor version', default=False)
 parser.add_option('-M', '--major', dest='update_major', action="store_true", help='With -l, update major version', default=False)
 parser.add_option('-V', '--version', dest='version', metavar="VERSION", help='With -l, set the version; use "-V v0.0.1" to bootstrap', default=False)
+parser.add_option('-v', '--verbose', dest='verbose', action="store_true", help='Increases verbosity)', default=False)
 parser.add_option('-u', '--update', dest='update', action="store_true", help='git pull target and libraries', default=False)
 parser.add_option('-s', '--status', dest='status', action="store_true", help='git status target and libraries', default=False)
 parser.add_option('-d', '--dev', dest='dev', action="store_true", help='enable developer mode (does not use target-locked.json)', default=False)
@@ -133,7 +134,7 @@ if not options.test_platform:
         generate_docs()
         exit(0)
 
-    build(options.clean)
+    build(options.clean, verbose=options.verbose)
     exit(0)
 
 for json_obj in test_json:

--- a/utils/python/codal_utils.py
+++ b/utils/python/codal_utils.py
@@ -20,7 +20,10 @@ def build(clean, verbose = False):
         system("cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -G \"Ninja\"")
 
         # build
-        system("ninja")
+        if verbose:
+            system("ninja --verbose")
+        else:
+            system("ninja")
     else:
         # configure
         system("cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -G \"Unix Makefiles\"")


### PR DESCRIPTION
Same PR as raised in:
- https://github.com/lancaster-university/microbit-v2-samples/pull/54

The plumbing was already in `build()`, just had to add the optparse entry.