### PR TITLE
Fix `build.py` `--clean` flag does actually clean with Ninja on Windows.

### DIFF
--- a/utils/python/codal_utils.py
+++ b/utils/python/codal_utils.py
@@ -19,6 +19,9 @@ def build(clean, verbose = False):
         # configure
         system("cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -G \"Ninja\"")
 
+        if clean:
+            system("ninja clean")
+
         # build
         system("ninja")
     else:


### PR DESCRIPTION
Mirrors the fix submitted to microbit-v2-samples:
- https://github.com/lancaster-university/microbit-v2-samples/pull/59