### PR TITLE
Increase CMake minimum version to 3.6.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.6)
 
 # include additional cmake
 include(utils/cmake/JSONParser.cmake)


### PR DESCRIPTION
There are some issues building the micro:bit target with CMake on Windows with versions 3.3 to 3.5.

3.3 was released in 2015 and 3.6.0 was release in 2016, more than 6 years ago: https://github.com/Kitware/CMake/commit/e31084e65745f9dd422c6aff0a2ed4ada6918805.

There is not much point trying to resolve the issue for such an old version of a tool, and because of that we aren't testing those versions in CI either, so let's move the min version to 3.6, which we are currently testing in CI in microbit-v2-samples.

Our main constrain is making sure the project stays compatible with CMake v3.8, as that's what's currently inside the MakeCode pxt yotta docker images, used to build CODAL as well.

This mirrors the change made in microbit-v2-samples:
- https://github.com/lancaster-university/microbit-v2-samples/pull/62