### PR TITLE
build.py: Fix option description for the `-t/test_platform` option

### DIFF
--- a/build.py
+++ b/build.py
@@ -33,7 +33,7 @@ from utils.python.codal_utils import system, build, read_json, checkgit, read_co
 
 parser = optparse.OptionParser(usage="usage: %prog target-name-or-url [options]", description="This script manages the build system for a codal device. Passing a target-name generates a codal.json for that devices, to list all devices available specify the target-name as 'ls'.")
 parser.add_option('-c', '--clean', dest='clean', action="store_true", help='Whether to clean before building. Applicable only to unix based builds.', default=False)
-parser.add_option('-t', '--test-platforms', dest='test_platform', action="store_true", help='Whether to clean before building. Applicable only to unix based builds.', default=False)
+parser.add_option('-t', '--test-platforms', dest='test_platform', action="store_true", help='Specify whether the target platform is a test platform or not.', default=False)
 parser.add_option('-l', '--lock', dest='lock_target', action="store_true", help='Create target-lock.json, updating patch version', default=False)
 parser.add_option('-b', '--branch', dest='branch', action="store_true", help='With -l, use vX.X.X-BRANCH.Y', default=False)
 parser.add_option('-m', '--minor', dest='update_minor', action="store_true", help='With -l, update minor version', default=False)


### PR DESCRIPTION
This patch was applied to microbit-v2-samples a few years ago and never made it here, so this PR applies the same commit from Raphael:
https://github.com/lancaster-university/microbit-v2-samples/commit/49f6dddad79b924092fea6b89fdd67da0ee218bd
